### PR TITLE
bugfix: encrypted message would be looked at as decrypted

### DIFF
--- a/server/ConnectionServer.cpp
+++ b/server/ConnectionServer.cpp
@@ -59,6 +59,9 @@ void ConnectionServer::initEncryption () {
 
 	//std::cout << "pubKey: " << _remotePublicKey << std::endl;
 
+	for ( auto& string: _messagesBuffer )
+		secretOpen(string);
+
 	_encrypted = true;
 }
 
@@ -137,7 +140,7 @@ std::string ConnectionServer::receiveInternal () {
 	const auto message = receive();
 
 	if ( !message.contains(_internal) )
-		throw std::runtime_error("Invalid message received (internal)");
+		throw std::runtime_error("Invalid message received (internal): " + message);
 
 	return message.substr(strlen(_internal));
 }
@@ -146,7 +149,7 @@ std::string ConnectionServer::receiveData () {
 	const auto message = receive();
 
 	if ( !message.contains(_data) )
-		throw std::runtime_error("Invalid message received (data)");
+		throw std::runtime_error("Invalid message received (data):" + message);
 
 	return message.substr(strlen(_data));
 }

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -1,6 +1,8 @@
+#include <algorithm>
 #include <condition_variable>
 #include <csignal>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <list>
@@ -8,11 +10,10 @@
 #include <vector>
 #include <netinet/in.h>
 #include <sys/socket.h>
-#include <filesystem>
 
-#include "terminal.cpp"
 #include "accepter.cpp"
 #include "ConnectionServer.h"
+#include "terminal.cpp"
 #include "utilServer.cpp"
 
 sig_atomic_t stopRequested = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 
+#include "CommandType.cpp"
 #include "Connection.h"
 #include "util.cpp"
-#include "CommandType.cpp"
 
 void sendFile ( std::ifstream& file, const std::ifstream::pos_type fileSize, Connection& connection ) {
 	if ( !file.good() ) {


### PR DESCRIPTION
this happened when client sent too many massages in handshake stage and some already encrypted messages would not be decrypted in messages buffer and when retrieved program would assume its okay to use